### PR TITLE
Fix security issu on default file access which is too wide

### DIFF
--- a/application/Handler.php
+++ b/application/Handler.php
@@ -12,9 +12,13 @@ namespace AAM\AddOn\ProtectedMediaFiles;
 /**
  * File access handler
  *
+ * @since 1.2.2 https://github.com/aamplugin/aam-protected-media-files/issues/12
+ *              https://github.com/aamplugin/aam-protected-media-files/issues/13
+ *              https://github.com/aamplugin/aam-protected-media-files/issues/14
+ *              https://github.com/aamplugin/aam-protected-media-files/issues/15
  * @since 1.2.0 https://github.com/aamplugin/aam-protected-media-files/issues/9
  * @since 1.1.7 https://github.com/aamplugin/aam-protected-media-files/issues/6
- * @since 1.1.6 Enhancement https://github.com/aamplugin/aam-protected-media-files/issues/4
+ * @since 1.1.6 https://github.com/aamplugin/aam-protected-media-files/issues/4
  * @since 1.1.4 Fixed bug with incorrectly computed path when DOCUMENT_ROOT does not
  *              match actual physical path
  * @since 1.1.3 Fixed bug with not properly managed access when website is in
@@ -26,7 +30,7 @@ namespace AAM\AddOn\ProtectedMediaFiles;
  *
  * @package AAM\AddOn\ProtectedMediaFiles
  * @author Vasyl Martyniuk <vasyl@vasyltech.com>
- * @version 1.2.0
+ * @version 1.2.2
  */
 class Handler
 {
@@ -95,6 +99,7 @@ class Handler
      *
      * @return void
      *
+     * @since 1.2.2 https://github.com/aamplugin/aam-protected-media-files/issues/15
      * @since 1.1.3 Changed the way full path is computed
      * @since 1.1.2 Fixed bug with incorrectly returned image size
      * @since 1.1.1 Fixed issue with incorrectly redirected user when access is
@@ -103,12 +108,12 @@ class Handler
      * @since 1.0.0 Initial implementation of the method
      *
      * @access public
-     * @version 1.1.3
+     * @version 1.2.2
      */
     public function authorize()
     {
         // First, let's check if URI is restricted
-        \AAM_Service_Uri::getInstance()->authorizeUri();
+        \AAM_Service_Uri::getInstance()->authorizeUri('/' . $this->request);
 
         $media = $this->findMedia();
 
@@ -204,12 +209,13 @@ class Handler
      *
      * @return string
      *
+     * @since 1.2.2 https://github.com/aamplugin/aam-protected-media-files/issues/14
      * @since 1.1.4 Fixed bug with incorrectly computed physical path if DOCUMENT_ROOT
      *              does not match actual physical path
      * @since 1.1.3 Initial implementation of the method
      *
      * @access private
-     * @version 1.1.4
+     * @version 1.2.2
      */
     private function _getFileFullpath()
     {
@@ -222,7 +228,14 @@ class Handler
             $request = $this->request;
         }
 
-        return ABSPATH . $request;
+        // To cover scenarios where the absolute path does not really reflect the
+        // actual path to the file (containerized WP instances).
+        $absdir = \AAM::api()->getConfig(
+            'addon.protected-media-files.settings.absolutePath',
+            ABSPATH
+        );
+
+        return $absdir . $request;
     }
 
     /**
@@ -233,16 +246,18 @@ class Handler
      *
      * @return void
      *
+     * @since 1.2.2 https://github.com/aamplugin/aam-protected-media-files/issues/13
      * @since 1.2.0 https://github.com/aamplugin/aam-protected-media-files/issues/9
      * @since 1.1.6 https://github.com/aamplugin/aam-protected-media-files/issues/3
      * @since 1.0.0 Initial implementation of the method
      *
      * @access private
-     * @version 1.2.0
+     * @version 1.2.2
      */
     private function _outputFile($filename, $mime = null)
     {
-		$filename = urldecode($filename); // PATCH YB required in order for the plugin to work with accents in url [ pour fonctionnement des url avec accents ]
+        $filename = realpath(urldecode($filename));
+
         if ($this->_isAllowed(realpath($filename))) {
             if (empty($mime)) {
                 if (function_exists('mime_content_type')) {
@@ -327,10 +342,13 @@ class Handler
      *
      * @return mixed
      *
+     * @since 1.2.2 https://github.com/aamplugin/aam-protected-media-files/issues/12
+     * @since 1.0.0 Initial implementation of the method
+     *
      * @access protected
-     * @version 1.0.0
+     * @version 1.2.2
      */
-    protected function getFromQuery($param, $filter = FILTER_DEFAULT, $options = null)
+    protected function getFromQuery($param, $filter = FILTER_DEFAULT, $options = 0)
     {
         $get = filter_input(INPUT_GET, $param, $filter, $options);
 
@@ -350,10 +368,13 @@ class Handler
      *
      * @return mixed
      *
+     * @since 1.2.2 https://github.com/aamplugin/aam-protected-media-files/issues/12
+     * @since 1.0.0 Initial implementation of the method
+     *
      * @access protected
-     * @version 1.0.0
+     * @version 1.2.2
      */
-    protected function getFromServer($param, $filter = FILTER_DEFAULT, $options = null)
+    protected function getFromServer($param, $filter = FILTER_DEFAULT, $options = 0)
     {
         $var = filter_input(INPUT_SERVER, $param, $filter, $options);
 

--- a/application/Handler.php
+++ b/application/Handler.php
@@ -242,6 +242,7 @@ class Handler
      */
     private function _outputFile($filename, $mime = null)
     {
+		$filename = urldecode($filename); // PATCH YB required in order for the plugin to work with accents in url [ pour fonctionnement des url avec accents ]
         if ($this->_isAllowed(realpath($filename))) {
             if (empty($mime)) {
                 if (function_exists('mime_content_type')) {
@@ -291,7 +292,8 @@ class Handler
      */
     private function _isAllowed($filename)
     {
-        $response = true; // By default, allowing access to request file unless ...
+        $response = false; // PATCH YB : secure file access, huge security hole, closed this after receiving several urgent alerts !! 
+						// true; // By default, allowing access to request file unless ...$response = true; // By default, allowing access to request file unless ...
 
         // Check if file extension is valid
         $type_check = wp_check_filetype(basename($filename));

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: AAM Protected Media Files
  * Description: Manage access to a physical file and prevent from a direct access
- * Version: 1.2.1
+ * Version: 1.2.2
  * Author: Vasyl Martyniuk <vasyl@vasyltech.com>
  * Author URI: https://vasyltech.com
  *
@@ -140,8 +140,6 @@ class Bootstrap
             exit(__('PHP 5.6.40 or higher is required.'));
         } elseif (version_compare($wp_version, '4.7.0') === -1) {
             exit(__('WP 4.7.0 or higher is required.'));
-        } elseif (!defined('AAM_VERSION') || (version_compare(AAM_VERSION, '6.0.3') === -1)) {
-            exit(__('Free Advanced Access Manager plugin 6.0.3 or higher is required.'));
         }
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: protected media, files, protected videos, documents, media library
 Requires at least: 4.7.0
 Requires PHP: 5.6.0
 License: GPLv2 or later
-Tested up to: 6.3.1
+Tested up to: 6.4.1
 Stable tag: 1.2.2
 
 Add-on to the free Advanced Access Manager plugin that protects media files from direct access for visitors, roles or users
@@ -17,18 +17,18 @@ Prevent direct access to the unlimited number of media library items either for 
 
 = Few Facts =
 
-* It requires a simple manual step in order to configure a webserver to protect direct access to `/wp-content/uploads` folder. For more information, please check [How to manage access to WordPress media library](https://aamplugin.com/article/how-to-manage-access-to-the-wordpress-media-library);
+* It requires a simple manual steps in order to configure a webserver to protect direct access to `/wp-content/uploads` folder. For more information, please check [our installation instructions](https://aamportal.com/article/protected-media-files-installation);
 * It does not change a physical file's location, content or URL. Upon deactivation, everything goes back to normal;
 * It protects all the allowed by WordPress core file types and those that are extended with third-party plugins (e.g. `.svg`, `.sketch`, etc.). For the list of all allowed extensions, check official WP documentation for the [wp_get_ext_types()](https://developer.wordpress.org/reference/functions/wp_get_ext_types/) core function;
-* It allows you to manage access to any media file for visitors, any individual user, roles or even define the default access to all media files for everybody (this one is available with [Plus Package](https://aamplugin.com/pricing/plus-package) add-on for AAM plugin);
+* It allows you to manage access to any media file for visitors, any individual user, roles or even define the default access to all media files for everybody (this one is available with [premium](https://aamportal.com/premium) add-on for AAM plugin);
 
-For more information about how properly install and use it, refer to [How to Manage Access to The WordPress Media Library](https://aamplugin.com/article/how-to-manage-access-to-the-wordpress-media-library) article.
+For more information about how properly install and use it, refer to [our documentation](https://aamportal.com/support).
 
 == Installation ==
 
-1. Upload `aam-protected-media-files` folder to the `/wp-content/plugins/` directory
-2. Activate the plugin through the 'Plugins' menu in WordPress
-3. Configure your webserver to redirect all media request to access handler as described in [How to Manage Access to The WordPress Media Library](https://aamplugin.com/article/how-to-manage-access-to-the-wordpress-media-library) article
+1. Upload `aam-protected-media-files` folder to the `/wp-content/plugins/` directory.
+2. Activate the plugin through the 'Plugins' menu in WordPress.
+3. Configure your webserver to redirect all media request to access handler as described in [installation guide](https://aamportal.com/article/protected-media-files-installation).
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Tags: protected media, files, protected videos, documents, media library
 Requires at least: 4.7.0
 Requires PHP: 5.6.0
 License: GPLv2 or later
-Tested up to: 6.1.1
-Stable tag: 1.2.0
+Tested up to: 6.3.1
+Stable tag: 1.2.2
 
 Add-on to the free Advanced Access Manager plugin that protects media files from direct access for visitors, roles or users
 
@@ -36,6 +36,15 @@ For more information about how properly install and use it, refer to [How to Man
 2. Restrict access to media file while editing it
 
 == Changelog ==
+
+= 1.2.2 =
+* Fixed: Deprecated PHP warning [https://github.com/aamplugin/aam-protected-media-files/issues/12](https://github.com/aamplugin/aam-protected-media-files/issues/12)
+* Fixed: Handle files with encoded characters [https://github.com/aamplugin/aam-protected-media-files/issues/13](https://github.com/aamplugin/aam-protected-media-files/issues/13)
+* Fixed: NGINX hard redirect issue [https://github.com/aamplugin/aam-protected-media-files/issues/15](https://github.com/aamplugin/aam-protected-media-files/issues/15)
+* Added New: Allow the ability to override the ABSPATH [https://github.com/aamplugin/aam-protected-media-files/issues/14](https://github.com/aamplugin/aam-protected-media-files/issues/14)
+
+= 1.2.1 =
+* Changed: Renamed the 401 redirect option to "Use Access Denied Redirect For Restricted Media Items"
 
 = 1.2.0 =
 * Fixed Bug: Fails to serve files with special characters [https://github.com/aamplugin/aam-protected-media-files/issues/7](https://github.com/aamplugin/aam-protected-media-files/issues/7)


### PR DESCRIPTION
* One with accented urls, which did not work (refused access). Problem is some users use accents in their file names
* Second issue is severe : the default behaviour was to allow access. I had to fix this urgently after several alertes received for documents that should not have beed made available because of this.